### PR TITLE
Add improvements

### DIFF
--- a/packages/toolpad-app/src/toolpad/AppEditor/HierarchyExplorer/index.tsx
+++ b/packages/toolpad-app/src/toolpad/AppEditor/HierarchyExplorer/index.tsx
@@ -193,17 +193,12 @@ export default function HierarchyExplorer({ className }: HierarchyExplorerProps)
       const deletedNode = appDom.getNode(dom, nodeId);
 
       let domViewAfterDelete: DomView | undefined;
-
       if (nodeId === activeNode) {
         const siblings = appDom.getSiblings(dom, deletedNode);
         const firstSiblingOfType = siblings.find((sibling) => sibling.type === deletedNode.type);
         domViewAfterDelete = firstSiblingOfType && getNodeEditorDomView(firstSiblingOfType);
       }
 
-      if (!domViewAfterDelete && activeNode) {
-        const current = appDom.getNode(dom, activeNode);
-        domViewAfterDelete = current && getNodeEditorDomView(current);
-      }
       await client.mutation.deletePage(deletedNode.name);
 
       appStateApi.update(

--- a/packages/toolpad-app/src/toolpad/AppEditor/index.tsx
+++ b/packages/toolpad-app/src/toolpad/AppEditor/index.tsx
@@ -50,8 +50,12 @@ function FileEditor() {
 
   const currentViewContent = React.useMemo(() => {
     switch (currentView.kind) {
-      case 'page':
-        return <PageEditor nodeId={currentView.nodeId} />;
+      case 'page': {
+        if (currentView.nodeId) {
+          return <PageEditor nodeId={currentView.nodeId} />;
+        }
+        return <NoPageFound />;
+      }
       default:
         return <NoPageFound />;
     }

--- a/packages/toolpad-app/src/utils/domView.ts
+++ b/packages/toolpad-app/src/utils/domView.ts
@@ -20,7 +20,7 @@ export type DomView =
 export function getPathnameFromView(view: DomView): string {
   switch (view.kind) {
     case 'page':
-      return `/app/pages/${view.nodeId}`;
+      return view.nodeId ? `/app/pages/${view.nodeId}` : '/app/pages';
     case 'connection':
       return `/app/connections/${view.nodeId}`;
     case 'codeComponent':

--- a/test/integration/editor/deleteLast.spec.ts
+++ b/test/integration/editor/deleteLast.spec.ts
@@ -1,0 +1,27 @@
+import { test, expect } from '../../playwright/localTest';
+import { ToolpadEditor } from '../../models/ToolpadEditor';
+
+test.use({
+  localAppConfig: {
+    cmd: 'dev',
+  },
+});
+
+test('do not find content if you delete page of middle ', async ({ page }) => {
+  const editorModel = new ToolpadEditor(page);
+  editorModel.goto();
+
+  const pageMenuItem = editorModel.getHierarchyItem('pages', 'page');
+
+  await pageMenuItem.hover();
+  await pageMenuItem.getByRole('button', { name: 'Open hierarchy menu' }).click();
+  await page.getByRole('menuitem', { name: 'Delete' }).click();
+  await page
+    .getByRole('dialog', { name: 'Confirm' })
+    .getByRole('button', { name: 'Delete' })
+    .click();
+
+  await expect(pageMenuItem).toBeHidden();
+  await expect(page.getByText('No pages in this app.')).toBeVisible();
+  await expect(page).toHaveURL('/_toolpad/app/pages');
+});

--- a/test/integration/pages/index.spec.ts
+++ b/test/integration/pages/index.spec.ts
@@ -29,20 +29,3 @@ test('must show a message when a non-existing url is accessed', async ({ page })
 
   await expect(page.getByText('Not found')).toBeVisible();
 });
-
-test('do not find content if you delete page of middle ', async ({ page }) => {
-  const editorModel = new ToolpadEditor(page);
-  editorModel.goto();
-
-  const pageMenuItem = editorModel.getHierarchyItem('pages', 'page1');
-  await pageMenuItem.hover();
-  await pageMenuItem.getByRole('button', { name: 'Open hierarchy menu' }).click();
-  await page.getByRole('menuitem', { name: 'Delete' }).click();
-  await page
-    .getByRole('dialog', { name: 'Confirm' })
-    .getByRole('button', { name: 'Delete' })
-    .click();
-
-  await expect(pageMenuItem).toBeHidden();
-  await expect(page.url().includes('undefined')).toBe(false);
-});


### PR DESCRIPTION
@JerryWu1234 I took a look at your PR https://github.com/mui/mui-toolpad/pull/2177. That test is a great addition. I propose a few changes to the implementation
1. Move the test into its own file so that we are certain it's the last page being deleted (otherwise the other tests in the file can influence the behavior)
2. I propose we show the `NoPageFound` when the last page is deleted, added a fix and added to your test
3. I propose we navigate to `/_toolpad/app/pages` after the last page is deleted . I added a fix and updated the test

What do you think?

(This PR targets your PR, so if you agree we can merge it in, or feel free to come up with a alternative implementation)